### PR TITLE
Add link to LAN/VLAN wiki guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,8 @@
 
                     <br><br>
 
+                    <p>We also have <a href="https://github.com/RLBot/RLBot/wiki/LAN-Setup">LAN/VLAN match support</a>, if you want to play with your friends!</p>
+
                     <p>
                         Join our <a href="https://discord.gg/zbaAKPt">Discord</a> chat server to participate in the community.
                         If you're ready to get started, you can read more on our <a href="https://github.com/RLBot/RLBot/wiki">wiki</a>


### PR DESCRIPTION
The link looks like this

![image](https://user-images.githubusercontent.com/35614515/135639441-5e60ce0d-9286-47a7-966e-ebb9b1e04114.png)

It's a commonly asked question in the discord, hopefully with this we'll get fewer people asking about it and even more just playing with their friends.