### PR TITLE
Update links to wiki

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -83,7 +83,7 @@
             <div class="card mb-3">
                 <div class="card-body">
                     <h5 id="rlbot-with-friends" class="card-title">Can I use RLBot with friends?</h5>
-                    <p>You can! It requires setting up a LAN/VLAN connection. <a href="https://github.com/RLBot/RLBot/wiki/LAN-Setup">Here is a guide</a>.</p>
+                    <p>You can! It requires setting up a LAN/VLAN connection. <a href="https://wiki.rlbot.org/miscellaneous/lan-setup/">Here is a guide</a>.</p>
 
                     <p>It is not possible to play with friends cross platform.</p>
                 </div>
@@ -96,7 +96,7 @@
                     <p>Most are hardcoded and do not use machine learning. However, since the release of
                         <a href="https://rlgym.github.io/">RLGym</a> the machine learning are progressing faster than
                         ever. If you are interesting in making a ML bot yourself, start by reading the
-                        <a href="https://github.com/RLBot/RLBot/wiki/Machine-Learning-FAQ">ML FAQ</a>.</p>
+                        <a href="https://wiki.rlbot.org/botmaking/machine-learning-faq/">ML FAQ</a>.</p>
 
                     <p>Some ML projects to check out are:</p>
                     <ul>
@@ -131,7 +131,7 @@
                     </ul>
 
                     <p>Addition resources, documentation, and examples can be found on the
-                        <a href="https://github.com/RLBot/RLBot/wiki">RLBot wiki</a>. Feel free to ask for help in the
+                        <a href="https://wiki.rlbot.org/">RLBot wiki</a>. Feel free to ask for help in the
                         <a href="https://discord.gg/zbaAKPt">Discord server</a> in the appropriate language channel or
                         in the #strategy or #mathematics channels.</p>
                 </div>
@@ -149,7 +149,7 @@
                         location and size of boost pads and the location of goals.</p>
 
                     <p>More information about the GameTickPacket, FieldInfo, and even the ControllerState can be
-                        on the <a href="https://github.com/RLBot/RLBotPythonExample/wiki/Input-and-Output-Data">RLBot wiki</a>.</p>
+                        on the <a href="https://wiki.rlbot.org/botmaking/input-and-output-data/">RLBot wiki</a>.</p>
                 </div>
             </div>
 
@@ -157,11 +157,11 @@
             <div class="card mb-3">
                 <div class="card-body">
                     <h5 id="useful-game-values" class="card-title">What is the dimensions of the field? Gravity? Ball radius? Max speed? Boost? Kickoff locations? etc?</h5>
-                    <p>All of these values can be found on <a href="https://github.com/RLBot/RLBot/wiki/Useful-Game-Values">RLBot wiki</a>.</p>
+                    <p>All of these values can be found on <a href="https://wiki.rlbot.org/botmaking/useful-game-values/">RLBot wiki</a>.</p>
 
-                    <p>To learn more about the physics of Rocket League, see <a href="https://samuelpmish.github.io/notes/RocketLeague/">chip's notes</a>.</p>
+                    <p>To learn more about the physics of Rocket League, see <a href="https://www.smish.dev/rocket_league/">chip's notes</a>.</p>
 
-                    <p>We also have a note on <a href="https://github.com/RLBot/RLBot/wiki/Jumping-Physics">jumping physics</a>.</p>
+                    <p>We also have a note on <a href="https://wiki.rlbot.org/botmaking/jumping-physics/">jumping physics</a>.</p>
 
                     <img src="https://i.imgur.com/nOz84cD.png" alt="game field dimensions" style="height: 400px"/>
                 </div>
@@ -173,10 +173,10 @@
                     <h5 id="debug-rendering-game-state-setting-ball-prediction-rlbottraining" class="card-title">How do I use debug rendering/game state setting/ball prediction/RLBotTraining?</h5>
                     <p>The RLBot framework comes with a set of useful features. Learn more about these here:</p>
                     <ul>
-                        <li><a href="https://github.com/RLBot/RLBot/wiki/Rendering">Debug rendering</a></li>
-                        <li><a href="https://github.com/RLBot/RLBot/wiki/Manipulating-Game-State">Game state setting/manipulation</a></li>
-                        <li><a href="https://github.com/RLBot/RLBot/wiki/Ball-Path-Prediction">Ball prediction</a></li>
-                        <li><a href="https://github.com/RLBot/RLBotPythonExample/wiki/Quickchat">Quick chat</a></li>
+                        <li><a href="https://wiki.rlbot.org/botmaking/rendering/">Debug rendering</a></li>
+                        <li><a href="https://wiki.rlbot.org/botmaking/manipulating-game-state/">Game state setting/manipulation</a></li>
+                        <li><a href="https://wiki.rlbot.org/botmaking/ball-path-prediction/">Ball prediction</a></li>
+                        <li><a href="https://wiki.rlbot.org/botmaking/quickchat/">Quick chat</a></li>
                         <li><a href="https://www.youtube.com/watch?v=uGFmOZCpel8&list=PL6LKXu1RlPdxh9vxmG1y2sghQwK47_gCH">RLBotTraining</a></li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -48,15 +48,15 @@
                     <img style="height:1.5em" src="rlbot_logo.png">
                         <a href="https://github.com/RLBot/RLBotGUI/releases/download/v1.0/RLBotGUI.msi" target="_blank"> Download RLBot for Windows</a>
                         or
-                        <a href="https://github.com/RLBot/RLBot/wiki/Operating-System-Support" target="_blank">see our OS support</a>.
+                        <a href="https://wiki.rlbot.org/framework/operating-system-support/" target="_blank">see our OS support</a>.
 
                     <br><br>
 
-                    <p>We also have <a href="https://github.com/RLBot/RLBot/wiki/LAN-Setup">LAN/VLAN match support</a>, if you want to play with your friends!</p>
+                    <p>We also have <a href="https://wiki.rlbot.org/miscellaneous/lan-setup/">LAN/VLAN match support</a>, if you want to play with your friends!</p>
 
                     <p>
                         Join our <a href="https://discord.gg/zbaAKPt">Discord</a> chat server to participate in the community.
-                        If you're ready to get started, you can read more on our <a href="https://github.com/RLBot/RLBot/wiki">wiki</a>
+                        If you're ready to get started, you can read more on our <a href="https://wiki.rlbot.org/">wiki</a>
                         or click your favourite language below!
                     </p>
                 </div>
@@ -173,6 +173,15 @@
                     <div class="card-body" style="text-decoration: none">
                         <h5 class="card-title">Tournaments</h5>
                         <p>Upcoming and previous tournaments</p>
+                    </div>
+                </div>
+            </a>
+
+            <a href="https://wiki.rlbot.org">
+                <div class="card mb-3 compact-card">
+                    <div class="card-body" style="text-decoration: none">
+                        <h5 class="card-title">Wiki</h5>
+                        <p>Everything to know about RLBot</p>
                     </div>
                 </div>
             </a>


### PR DESCRIPTION
This PR adds a card to the front page with a link to the [new wiki](https://wiki.rlbot.org/). All links pointing to the old wiki have also been updated to point to the new wiki.