### PR TITLE
Change download link to new launcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                     <a href="https://youtu.be/oXkbizklI2U" target="_blank" style="margin-right: 20px">
                         <img style="height:1.5em" src="youtube.png"> Quick Start Video</a>
                     <img style="height:1.5em" src="rlbot_logo.png">
-                        <a href="https://github.com/RLBot/RLBotGUI/releases/download/v1.0/RLBotGUI.msi" target="_blank"> Download RLBot for Windows</a>
+                        <a href="https://github.com/RLBot/RLBotGUI/releases/download/v1.0/rlbotguilauncher.exe" target="_blank"> Download RLBot for Windows</a>
                         or
                         <a href="https://wiki.rlbot.org/framework/operating-system-support/" target="_blank">see our OS support</a>.
 


### PR DESCRIPTION
I uploaded swz's launcher to https://github.com/RLBot/RLBotGUI/releases/tag/v1.0
Downloaded from https://github.com/swz-git/guilauncher/releases/tag/v0.5.0